### PR TITLE
Add `startPosition` property support

### DIFF
--- a/src/components/video.tsx
+++ b/src/components/video.tsx
@@ -42,6 +42,7 @@ export type ReactNativeKinescopeVideoProps = ReactVideoPropsOmit &
 		autoSeekChangeQuality?: boolean; // ios only
 		referer?: string;
 		drmAuthToken?: string;
+		startPosition?: number;
 	};
 
 function ReactNativeKinescopeVideo(
@@ -51,6 +52,7 @@ function ReactNativeKinescopeVideo(
 	const {
 		preload,
 		videoId,
+		startPosition,
 		posterResizeMode,
 		externalId,
 		quality = 'auto',
@@ -277,6 +279,7 @@ function ReactNativeKinescopeVideo(
 		if (Platform.OS === 'android' && manifest.dashLink) {
 			return {
 				uri: manifest.dashLink,
+				startPosition: startPosition,
 				type: 'mpd',
 				headers: {
 					...headers,
@@ -286,6 +289,7 @@ function ReactNativeKinescopeVideo(
 		}
 		return {
 			uri: getHlsLink(),
+			startPosition: startPosition,
 			type: 'm3u8',
 			headers: headers,
 		};


### PR DESCRIPTION
According to the `react-native-video` [docs](https://docs.thewidlarzgroup.com/react-native-video/component/props#start-playback-at-a-specific-point-in-time) the possibility to start video playback from a specific time is defined via the `source` property which is hidden under `<ReactNativeKinescopeVideo />` component.
This pull request adds a `startPosition` property to `<ReactNativeKinescopeVideo />` component.